### PR TITLE
Allow arbitrary info objects for binds

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,13 +109,15 @@ Initializes the library. In the event of an error `callback(info, rawError)` wil
 
 - `rawError`: The raw error object that generated the event, if available. This is not guaranteed to be JSON safe.
 
-### #run(name, callback)
+### #run(name, [info, ] callback)
 
 Creates a new named section and executes immediately. This allows for easy creation of new section scopes.
 
-### #bind([name, ] callback)
+### #bind([name, ]\[info, ] callback)
 
 Creates a section which may be executed at a later time. If `name` is omitted then the section will execute under the current section name. This is useful for providing callbacks to methods that do not use one of the automaticly bound paths.
+
+If an `info` object is provided, the data passed on error will be extended with any values defined on `info`. This may be used for passing arbitrary debugging data back to the tracking system.
 
 ### #current()
 

--- a/js/costanza.js
+++ b/js/costanza.js
@@ -66,7 +66,7 @@ this.Costanza = (function() {
         args[0] = bind(callback);
 
         return $super.apply(this, args);
-      };
+      }
       ret._costanza = true;
       return ret;
     }
@@ -141,10 +141,21 @@ this.Costanza = (function() {
     }
   }
 
-  function bind(name, callback) {
-    if (!callback) {
-      callback = name;
-      name = currentSection;
+  function bind(/* [name, ][info, ] callback */) {
+    var callback = arguments[2] || arguments[1] || arguments[0],
+        info,
+        name = currentSection;
+
+    if (arguments.length > 2) {
+      info = arguments[1];
+      name = arguments[0];
+    }
+    if (arguments.length > 1) {
+      name = arguments[0];
+      if (typeof name !== 'string') {
+        info = name;
+        name = currentSection;
+      }
     }
 
     if (callback._costanza) {
@@ -159,12 +170,23 @@ this.Costanza = (function() {
 
         return callback.apply(this, arguments);
       } catch (err) {
-        reportCallback({
+        var reportInfo = {
           type: 'javascript',
           section: currentSection,
           msg: err.message,
           stack: err.stack
-        }, err);
+        };
+
+        // Inline debug data
+        if (info) {
+          for (var keyName in info) {
+            if (info.hasOwnProperty(keyName)) {
+              reportInfo[keyName] = info[keyName];
+            }
+          }
+        }
+
+        reportCallback(reportInfo, err);
       } finally {
         currentSection = priorSite;
       }
@@ -237,8 +259,8 @@ this.Costanza = (function() {
       reportCallback(info, error);
     },
     bind: bind,
-    run: function(name, callback) {
-      bind(name, callback)();
+    run: function(name, info, callback) {
+      bind(name, info, callback)();
     },
     onError: onError
   };

--- a/test/js/costanza.js
+++ b/test/js/costanza.js
@@ -53,6 +53,47 @@ describe('costanza', function() {
         error);
       done();
     });
+    it('report errors', function(done) {
+      Costanza.run('fail!', function() {
+        throw error;
+      });
+      expect(spy).to.have.been.calledWith({
+          type: 'javascript',
+          section: 'fail!',
+          msg: 'Failure is always an option',
+          stack: error.stack
+        },
+        error);
+      done();
+    });
+    it('report info', function(done) {
+      Costanza.run({foo: true}, function() {
+        throw error;
+      });
+      expect(spy).to.have.been.calledWith({
+          type: 'javascript',
+          section: 'global',
+          foo: true,
+          msg: 'Failure is always an option',
+          stack: error.stack
+        },
+        error);
+      done();
+    });
+    it('report errors and info', function(done) {
+      Costanza.run('fail!', {foo: true}, function() {
+        throw error;
+      });
+      expect(spy).to.have.been.calledWith({
+          type: 'javascript',
+          section: 'fail!',
+          foo: true,
+          msg: 'Failure is always an option',
+          stack: error.stack
+        },
+        error);
+      done();
+    });
     it('should restore the site', function(done) {
       var section1 = Costanza.bind('success', function() {
         expect(Costanza.current()).to.equal('success');


### PR DESCRIPTION
Allows the callers to associate additional debugging information with
sections.
