### PR TITLE
Fix for Event Handlers on SVG Elements with a class.

### DIFF
--- a/js/costanza.js
+++ b/js/costanza.js
@@ -95,16 +95,16 @@ this.Costanza = (function() {
       proto._addEventListener = proto.addEventListener;
       proto.addEventListener = function(type, callback, useCapture) {
         if (!callback._section) {
-	        var className = '';
-	        if (this.className) {
-		        // baseValue for SVGAnimatedString on svg elements
-		        className = this.className.baseVal || this.className;
-		        className = '.' + className.replace(' ', '.');
-	        }
+          var className = '';
+          if (this.className) {
+            // baseValue for SVGAnimatedString on svg elements
+            className = this.className.baseVal || this.className;
+            className = '.' + className.replace(' ', '.');
+          }
 
-	        var elementId = (this.nodeName || 'window').toLowerCase()
-			        + (this.id ? '#' + this.id : className),
-		        sectionName = 'event-' + elementId + ':' + type;
+          var elementId = (this.nodeName || 'window').toLowerCase()
+              + (this.id ? '#' + this.id : className),
+            sectionName = 'event-' + elementId + ':' + type;
 
           if (callback.handleEvent) {
             callback._section = {


### PR DESCRIPTION
On SVGElements the class attribute is an instance of SVGAnimatedString. This object doesn't have a replace method.

For svg elements we should use className.baseVal as value instead of the  className to prevent runtime errors
